### PR TITLE
Enhancement: Percentage Loader

### DIFF
--- a/app/app/_components/GenerateContent.tsx
+++ b/app/app/_components/GenerateContent.tsx
@@ -130,6 +130,7 @@ function GenerateContent() {
     setSelectedFile(null);
     setExtractedText("");
     setShowCandidateInfo(false);
+    setShowNotes(false);
     setCandidateData({
       documentTitle: "",
       name: "",
@@ -141,7 +142,7 @@ function GenerateContent() {
     setGeneratedCV(null);
   };
 
-  if (!isGenerating) {
+  if (isGenerating) {
     return (
       <section className="flex flex-col justify-center items-center min-h-[93vh] layout">
         <Spinner progress={generationProgress} />

--- a/components/global/Spinner.tsx
+++ b/components/global/Spinner.tsx
@@ -1,8 +1,21 @@
-export function Spinner() {
+interface SpinnerProps {
+  progress?: number;
+}
+
+export function Spinner({ progress }: SpinnerProps) {
   return (
-    /* pretty! */
-    <div className="flex flex-col items-center justify-center">
-      <div className="h-16 w-16 animate-spin rounded-full border-t-4 border-solid border-blue-500"></div>
+    <div className="flex flex-col justify-center items-center gap-8">
+      <div className="border-t-4 border-blue-500 border-solid rounded-full w-16 h-16 animate-spin"></div>
+      {typeof progress === "number" && (
+        <div className="flex flex-col items-center gap-2">
+          <div className="bg-gray-200 dark:bg-gray-700 rounded-full w-48 h-2 overflow-hidden">
+            <div
+              className="bg-blue-500 rounded-full h-full transition-all duration-300 ease-in-out"
+              style={{ width: `${Math.min(100, Math.max(0, progress))}%` }}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Changes
- Added a simulated progress indicator during CV generation that:
  - Reaches 99% in 10 seconds
  - Only shows 100% on successful generation
  - Stays at 99% if generation takes longer than expected
  - Note: Progress is simulated and not tied to actual generation progress
- Fixed form reset flow to properly reset all states including `showNotes`
- Progress stays at 99% during extended generations (Netflix also does this lol)

## Testing
- Verify progress bar appears and smoothly progresses during generation
- Confirm reset button returns to file upload step with all form fields cleared
- Check that next navigation after reset shows correct candidate info form