### PR TITLE
style: refine sign in page visual

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Image from "next/image";
+import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { signIn } from "@/auth";
@@ -9,14 +10,17 @@ import {
   Card,
   CardContent,
   CardDescription,
+  CardFooter,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
 
 import getSession from "@/lib/getSession";
 
 export const metadata: Metadata = {
-  title: "Login",
+  title: "Login | ProfilePrep",
+  description: "Sign in to your ProfilePrep account",
 };
 
 interface PageProps {
@@ -25,28 +29,31 @@ interface PageProps {
 
 export default async function LoginPage({ searchParams }: PageProps) {
   const session = await getSession();
-
   const params = await searchParams; // Need to await dynamic APIs in Next.js 15
-
   const redirectUrl = params.redirectUrl;
 
   if (session) redirect("/app");
 
   return (
-    <section className="flex h-[93vh] w-full items-center justify-center">
-      <Card className="mx-auto max-w-sm bg-background/40 md:min-w-[400px]">
-        <CardHeader>
-          <CardTitle className="text-center text-2xl">
-            <h1 className="text-xl font-bold tracking-wider">
-              Profile<span className="text-primary">Prep</span>
-            </h1>
-          </CardTitle>
-          <CardDescription className="text-center">
-            Connect an account to login
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="grid">
+    <section className="flex min-h-[93vh] w-full items-center justify-center p-4">
+      <div className="relative w-full max-w-md">
+        <Card className="relative overflow-hidden border-t-4 border-t-primary bg-background/40 backdrop-blur-sm transition-all duration-300">
+          <div className="absolute inset-0 bg-gradient-to-b from-primary/5 to-transparent opacity-50" />
+
+          <CardHeader className="relative space-y-4 pt-8">
+            <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
+              <CardTitle className="text-center">
+                <h1 className="text-2xl font-bold tracking-wider">
+                  Profile<span className="text-primary">Prep</span>
+                </h1>
+              </CardTitle>
+            </div>
+            <CardDescription className="text-center text-base">
+              Connect your account to login
+            </CardDescription>
+          </CardHeader>
+
+          <CardContent className="relative space-y-6 pb-8 pt-2">
             <form
               action={async () => {
                 "use server";
@@ -64,14 +71,45 @@ export default async function LoginPage({ searchParams }: PageProps) {
                   src={"/google.svg"}
                   width={20}
                   height={20}
-                  alt="google logo"
+                  alt="Google logo"
+                  className="transition-transform group-hover:scale-110"
                 />
-                Google
+                <span className="font-medium">Continue with Google</span>
               </Button>
             </form>
-          </div>
-        </CardContent>
-      </Card>
+
+            <div className="flex items-center gap-3 px-2">
+              <Separator className="flex-1" />
+              <span className="text-xs text-muted-foreground">
+                Welcome, Profile<span className="text-primary">Prepper</span>
+              </span>
+              <Separator className="flex-1" />
+            </div>
+
+            <div className="rounded-lg bg-primary/5 p-4">
+              <p className="text-center text-sm text-muted-foreground">
+                By signing in, you agree to our{" "}
+                <Link href="#" className="text-primary hover:underline">
+                  Terms of Service
+                </Link>{" "}
+                and{" "}
+                <Link href="#" className="text-primary hover:underline">
+                  Privacy Policy
+                </Link>
+              </p>
+            </div>
+          </CardContent>
+
+          <CardFooter className="flex justify-center border-t bg-muted/20 pb-6 pt-4">
+            <p className="text-sm text-muted-foreground">
+              Need help?{" "}
+              <Link href="#" className="text-primary hover:underline">
+                Contact Support
+              </Link>
+            </p>
+          </CardFooter>
+        </Card>
+      </div>
     </section>
   );
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -14,7 +14,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
 
 import getSession from "@/lib/getSession";
 
@@ -77,6 +76,14 @@ export default async function LoginPage({ searchParams }: PageProps) {
                 <span className="font-medium">Continue with Google</span>
               </Button>
             </form>
+
+            {/* <div className="flex items-center gap-3 px-2">
+              <Separator className="flex-1" />
+              <span className="text-muted-foreground text-xs">
+                Welcome, Profile<span className="text-primary">Prep</span>
+              </span>
+              <Separator className="flex-1" />
+            </div> */}
 
             <div className="rounded-lg bg-primary/5 p-4">
               <p className="text-center text-sm text-muted-foreground">

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -78,14 +78,6 @@ export default async function LoginPage({ searchParams }: PageProps) {
               </Button>
             </form>
 
-            <div className="flex items-center gap-3 px-2">
-              <Separator className="flex-1" />
-              <span className="text-xs text-muted-foreground">
-                Welcome, Profile<span className="text-primary">Prepper</span>
-              </span>
-              <Separator className="flex-1" />
-            </div>
-
             <div className="rounded-lg bg-primary/5 p-4">
               <p className="text-center text-sm text-muted-foreground">
                 By signing in, you agree to our{" "}

--- a/components/global/Footer.tsx
+++ b/components/global/Footer.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from "next/navigation";
 
 import InfoButton from "@/components/global/InfoButton";
+import LogoutButton from "@/components/global/LogoutButton";
 import ThemeToggle from "@/components/global/ThemeToggle";
 
 function Footer() {
@@ -15,7 +16,12 @@ function Footer() {
       </h1>
 
       <div className="flex gap-2">
-        {pathname === "/app" && <InfoButton />}
+        {pathname === "/app" && (
+          <>
+            <LogoutButton />
+            <InfoButton />
+          </>
+        )}
         <ThemeToggle />
       </div>
     </footer>

--- a/components/global/LogoutButton.tsx
+++ b/components/global/LogoutButton.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React from "react";
+
+import { useRouter } from "next/navigation";
+
+import { motion } from "framer-motion";
+import { PowerCircle } from "lucide-react";
+import { signOut } from "next-auth/react";
+
+import { Button } from "@/components/ui/button";
+
+export default function LogoutButton() {
+  const router = useRouter();
+
+  async function handleLogout() {
+    await signOut();
+    router.push("/login");
+  }
+
+  return (
+    <>
+      <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={handleLogout}
+          aria-label="AI Information"
+          className="relative h-9 w-9 rounded-full bg-input/50"
+        >
+          <PowerCircle size={16} />
+        </Button>
+      </motion.div>
+    </>
+  );
+}

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import * as React from "react";
+
+import * as SeparatorPrimitive from "@radix-ui/react-separator";
+
+import { cn } from "@/lib/utils";
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref,
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Separator.displayName = SeparatorPrimitive.Root.displayName;
+
+export { Separator };

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.6",
         "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-select": "^2.1.6",
+        "@radix-ui/react-separator": "^1.1.2",
         "@radix-ui/react-slot": "^1.1.2",
         "@radix-ui/react-switch": "^1.1.3",
         "@radix-ui/react-tooltip": "^1.1.8",
@@ -3120,6 +3121,29 @@
         "@radix-ui/react-visually-hidden": "1.1.2",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.2.tgz",
+      "integrity": "sha512-oZfHcaAp2Y6KFBX6I5P1u7CQoy4lheCGiYj+pGFrHy8E/VNRb5E39TkTr3JrV520csPBTZjkuKFdEsjS5EUNKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.6",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-select": "^2.1.6",
+    "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-switch": "^1.1.3",
     "@radix-ui/react-tooltip": "^1.1.8",


### PR DESCRIPTION
feat: add logout button

ui: refine sign-in page styling

preview currently:

- dark mode
<img width="506" alt="sign-in-page-dark-mode-current" src="https://github.com/user-attachments/assets/90f482b3-bfed-4ca2-ac3e-15b0fb66cc60" />

- light mode
<img width="530" alt="sign-in-page-light-mode-current" src="https://github.com/user-attachments/assets/c886bed2-9d83-44cb-86d0-dc6a6c190bfc" />

proposed alternative if the display above appears to be a tad much:
_**(please do not merge this PR if the visual below is preferred, until the updates to render it are committed)**_

- dark mode
<img width="495" alt="sign-in-page-dark-mode-potential" src="https://github.com/user-attachments/assets/d27ee569-3ebf-47ea-bf9a-917886d5df37" />

- light mode
<img width="495" alt="sign-in-page-light-mode-potential" src="https://github.com/user-attachments/assets/60b20976-a1fd-411f-aafa-91c68e375925" />

